### PR TITLE
Fix sorting by job id by specifying the sorting algorithm to use

### DIFF
--- a/scripts/controllers/my-jobs.controller.js
+++ b/scripts/controllers/my-jobs.controller.js
@@ -31,20 +31,21 @@
             appScopeProvider: this
             }, {
             "enableFiltering": true,
-                "columnDefs": [
-                    {
-                        "field": "jobId"
-                    },
-                    {
-                        "field": "name"
-                    },
-                    {
-                        "field": "date"
-                    },
-                    {
-                        "field": "status"
-                    }
-                ]
+            "columnDefs": [
+                {
+                    "field": "jobId",
+                    sortingAlgorithm: function(a, b) { return Math.sign(a - b);}
+                },
+                {
+                    "field": "name"
+                },
+                {
+                    "field": "date"
+                },
+                {
+                    "field": "status"
+                }
+            ]
         });
 
         setUpGridOptions();


### PR DESCRIPTION
Fix sorting by job id by specifying the sorting algorithm to use: (ng-grid was not picking up the datatype automatically and so was sorting it by string).