### PR TITLE
move dataset info into one column

### DIFF
--- a/config/lang.json
+++ b/config/lang.json
@@ -554,8 +554,8 @@
         },
         "DATASET_TYPE" : {
             "TABTITLE" : "Dataset Type",
-            "NAME" : "Name",
-            "DESCRIPTION" : "Description"
+            "NAME" : "Dataset Type",
+            "DESCRIPTION" : "Dataset Type Description"
         },
         "DATASET_PARAMETER" : {
             "TABTITLE" : "Dataset Parameters",

--- a/config/topcat.json
+++ b/config/topcat.json
@@ -429,12 +429,7 @@
                                 {
                                     "field": "modTime",
                                     "template": "{{item.value | date:'yyyy-MM-dd HH:mm:ss'}}"
-                                }
-                            ]
-                        },
-                        {
-                            "title": "METATABS.DATAFILE.PARAMETERS",
-                            "items": [
+                                },
                                 {
                                     "label": "",
                                     "field": "datasetParameter[entity.type.valueType=='STRING'].stringValue",
@@ -449,12 +444,7 @@
                                     "label": "",
                                     "field": "datasetParameter[entity.type.valueType=='DATE_AND_TIME'].datetimeValue",
                                     "template": "<span class='label'>{{item.entity.type.name}}</span><span class='value'>{{item.value | date:'yyyy-MM-dd'}}</span>"
-                                }
-                            ]
-                        },
-                        {
-                            "title": "METATABS.DATASET_TYPE.TABTITLE",
-                            "items": [
+                                },
                                 {
                                     "field": "datasetType.name"
                                 },


### PR DESCRIPTION
closes #17 

Moves all of the dataset details into one column.

Example:
![image](https://cloud.githubusercontent.com/assets/13658288/20175722/1cfe8124-a73c-11e6-87ce-05dc957d91a3.png)

