### PR TITLE
Update how the plugin modifies the topcat schema to match TopCAT 2.2.0

### DIFF
--- a/config/lang.json
+++ b/config/lang.json
@@ -154,8 +154,8 @@
                 "DOI": "Doi",
                 "FILE_SIZE": "File Size",
                 "CHECKSUM": "Checksum",
-                "DATAFILE_CREATE_TIME": "Create Time",
-                "DATAFILE_MOD_TIME": "Modified Time"
+                "CREATE_TIME": "Create Time",
+                "MOD_TIME": "Modified Time"
             },
             "ACTIONS":{
                 "NAME": "Actions",
@@ -786,5 +786,28 @@
         "MINUTES": "minutes",
         "SECOND": "second",
         "SECONDS": "seconds"
+    },
+    "DOWNLOAD_ENTITY_ACTION_BUTTON": {
+        "TEXT": "Download",
+        "TOOLTIP": {
+            "TEXT": "Click to download"
+        }
+    },
+    "CONFIGURE_JOB_ENTITY_ACTION_BUTTON": {
+        "TEXT": "Configure Job",
+        "TOOLTIP": {
+            "TEXT": "Configure job"
+        }
+    },
+    "LANDING_PAGE": {
+        "DOWNLOAD": {
+            "TITLE": "Download",
+            "NEXT_BUTTON": {
+                "TEXT": "Next"
+            },
+            "CANCEL_BUTTON": {
+                "TEXT": "Cancel"
+            }
+        }
     }
 }

--- a/config/topcat.json
+++ b/config/topcat.json
@@ -480,7 +480,10 @@
                             {
                                 "field": "modTime"
                             }
-                        ]
+                        ],
+                        "externalSelectFilters": {
+                            "filters": [
+                            ]
                     },
                     "metaTabs": [
                         {

--- a/scripts/plugin.js
+++ b/scripts/plugin.js
@@ -22,145 +22,41 @@ registerTopcatPlugin(function(pluginUrl){
             stylesUrl + 'main.css'
         ],
 
-        configSchema: function(){
-            this.attribute('facilities', function(){
-                    this.type('array');
-                    this.attribute('*', function(){
-                        this.attribute('title', function(){ this.type("string"); });
-                        this.attribute('name', function(){ this.type("string"); });
-                        this.attribute('idsUrl', function(){ this.type("string"); });
-                        this.attribute('icatUrl', function(){ this.type("string"); this.mandatory(false); });
-                        this.attribute('ijpUrl', function(){ this.type("string"); this.mandatory(false); });
-                        this.attribute('hierarchy', function(){
-                            this.type('array');
-                            this.attribute('*', function(){
-                                this.type("string");
-                            });
-                        });
-                        this.attribute('authenticationTypes', function(){
-                            this.type('array');
-                            this.attribute('*', function(){
-                                this.attribute('title', function(){ this.type("string"); });
-                                this.attribute('plugin', function(){ this.type("string"); });
-                                this.attribute('casUrl', function(){ this.type("string"); this.mandatory(function(o){
-                                    return o.plugin == 'cas';
-                                }); });
-                            });
-                        });
-                        this.attribute('downloadTransportTypes', function(){
-                            this.type('array');
-                            this.mandatory(false);
-                            this.attribute('*', function(){
-                                this.attribute('type', function(){ this.type("string"); });
-                                this.attribute('idsUrl', function(){ this.type("string"); });
-                            });
-                        });
-                        this.attribute('admin', function(){
-                            this.attribute('gridOptions', function(){
-                                this.attribute('columnDefs', function(){
-                                    this.type('array');
-                                    this.attribute('*', function(){
-                                        this.attribute('title', function(){ this.type("string"); this.mandatory(false); });
-                                        this.attribute('field', function(){ this.type("string"); });
-                                        this.attribute('cellTemplate', function(){ this.type('string'); this.mandatory(false); });
-                                    });
-                                });
-                            });
-                        });
-                        this.attribute('myData', function(){
-                            this.attribute('entityType', function(){ this.type('string'); });
-                            this.attribute('gridOptions', function(){
-                                this.attribute('enableSelection', function(){ this.type('boolean'); this.mandatory(false); });
-                                this.attribute('columnDefs', function(){
-                                    this.type('array');
-                                    this.attribute('*', function(){
-                                        this.attribute('title', function(){ this.type("string"); this.mandatory(false); });
-                                        this.attribute('field', function(){ this.type("string"); });
-                                        this.attribute('cellTemplate', function(){ this.type('string'); this.mandatory(false); });
-                                        this.attribute('jpqlFilter', function(){ this.type('string'); this.mandatory(false); });
-                                        this.attribute('jpqlSort', function(){ this.type('string'); this.mandatory(false); });
-                                        this.attribute('link', function(){ this.type('boolean|string'); this.mandatory(false); });
-                                        this.attribute('where', function(){ this.type('string'); this.mandatory(false); });
-                                        this.attribute('excludeFuture', function(){ this.type('boolean'); this.mandatory(false); });
-                                        this.attribute('sort', function(){
-                                            this.mandatory(false);
-                                            this.attribute('direction', function(){ this.type("string"); });
-                                            this.attribute('priority', function(){ this.type("number"); this.mandatory(false); });
-                                        });
-                                    });
-                                });
-                            });
-                        });
-                        this.attribute('browse', function(){
-                            var that = this;
-                            _.each(["instrument", "facilityCycle", "investigation", "proposal", "dataset", "datafile"], function(entityType){
-                                that.attribute(entityType, function(){
-                                    this.mandatory(false);
-                                    this.attribute('skipSingleEntities', function(){ this.type('boolean'); this.mandatory(false); });
-                                    this.attribute('gridOptions', function(){
-                                        if(entityType == 'investigation' || entityType == 'dataset' || entityType == 'datafile'){
-                                            this.attribute('enableSelection', function(){ this.type('boolean'); this.mandatory(false); });
-                                        }
-                                        if(entityType == 'dataset' || entityType == 'datafile'){
-                                            this.attribute('enableConfigureJob', function(){ this.type('boolean'); this.mandatory(false); });
-                                        }
-                                        if(entityType == 'datafile'){
-                                            this.attribute('enableDownload', function(){ this.type('boolean'); this.mandatory(false); });
-                                        }
-                                        this.attribute('externalSelectFilters', function(){
-                                            this.mandatory(false);
-                                            if(entityType == 'dataset'){
-                                                this.attribute('enableJobTypeFilter', function(){ this.type('boolean'); this.mandatory(false); });
-                                            }
-                                            this.attribute('filters', function(){
-                                                this.type('array');
-                                                this.attribute('*', function(){
-                                                    this.attribute('field', function(){ this.type('string'); this.mandatory(false); })
-                                                });
-                                            });
-                                        });
-                                        this.attribute('columnDefs', function(){
-                                            this.type('array');
-                                            this.attribute('*', function(){
-                                                this.attribute('title', function(){ this.type('string'); this.mandatory(false); });
-                                                this.attribute('field', function(){ this.type('string'); });
-                                                this.attribute('cellTemplate', function(){ this.type('string'); this.mandatory(false); });
-                                                this.attribute('jpqlFilter', function(){ this.type('string'); this.mandatory(false); });
-                                                this.attribute('jpqlSort', function(){ this.type('string'); this.mandatory(false); });
-                                                this.attribute('link', function(){ this.type('boolean|string'); this.mandatory(false); });
-                                                this.attribute('where', function(){ this.type('string'); this.mandatory(false); });
-                                                this.attribute('excludeFuture', function(){ this.type('boolean'); this.mandatory(false); });
-                                                this.attribute('breadcrumb', function(){ this.type('boolean'); this.mandatory(false); });
-                                                this.attribute('breadcrumbTemplate', function(){ this.type('string'); this.mandatory(false); });
-                                                this.attribute('sort', function(){
-                                                    this.mandatory(false);
-                                                    this.attribute('direction', function(){ this.type("string"); });
-                                                    this.attribute('priority', function(){ this.type("number"); this.mandatory(false); });
-                                                });
-                                            });
-                                        });
-                                    });
-                                    this.attribute('metaTabs', function(){
-                                        this.type('array');
-                                        this.mandatory(false);
-                                        this.attribute('*', function(){
-                                            this.attribute('title', function(){ this.type("string"); });
-                                            this.attribute('items', function(){
-                                                this.type('array');
-                                                this.attribute('*', function(){
-                                                    this.attribute('field', function(){ this.type("string"); });
-                                                    this.attribute('label', function(){ this.type("string"); this.mandatory(false); });
-                                                    this.attribute('template', function(){ this.type("string"); this.mandatory(false); });
-                                                });
-                                            });
-                                        });
-                                    });
-                                });
-                            });
-                        });
-
-                    });
-                });
+        configSchema: {
+    	    facilities: {
+    	        _item: {
+    	            ijpUrl: { _type: 'string', _mandatory: false },
+    	            browse:{
+    	                dataset: {
+    	                     gridOptions: {
+        	                     enableConfigureJob: { _type: 'boolean' },
+    	                         externalSelectFilters: {
+    	                             enableJobTypeFilter: { _type: 'boolean' },
+    	                             filters: {
+    	                                    _type: 'array',
+    	                                    _item: {
+    	                                        field: { _type: 'string'}
+    	                                    }
+    	                             },
+    	                         }
+    	                     }
+    	                },
+    	                datafile: {
+    	                     gridOptions: {
+        	                     enableConfigureJob: { _type: 'boolean' },
+    	                         externalSelectFilters: {
+    	                             filters: {
+    	                                    _type: 'array',
+    	                                    _item: {
+    	                                        field: { _type: 'string'}
+    	                                    }
+    	                             },
+    	                         }
+    	                     }
+    	                }
+    	            }
+    	        }
+    	    }
         },
 
         setup: function($rootScope, $state, $uibModal, $q, tc, icatSchema, helpers){


### PR DESCRIPTION
Fixes #19

plugin.js : change configSchema to match TopCAT 2.2.0's plugin support,
i.e. make it a map that describes (only) new contents required/supported
by the IJP plugin.

topcat.json : add empty externalSelectFilters to browse/datafile, in
line with modified schema.

lang.json : add extra elements from TopCAT 2.2.0's lang.json; remove
DATAFILE_ prefix from browse/datafile create/mod time column titles (as
code expects no prefix).