### PR TITLE
Report job submission error messages to user

### DIFF
--- a/src/main/webapp/scripts/controllers/configure-job.controller.js
+++ b/src/main/webapp/scripts/controllers/configure-job.controller.js
@@ -151,9 +151,11 @@
                         //Multiple jobs can only be submitted at once if the job is a batch job, so the response must have an id
                         that.jobIds.push(response.jobId);
                     }, function(response){
+                    	var message = "Submit failed but no error response was received";
+                    	if (response && response.message) message = response.message;
                         that.failedSubmissions.push({
-                            inputEntityIds: inputEntity.entityId,
-                            error: response || "No error response"
+                            inputEntityIds: _.map(inputEntities, 'entityId').join(', '),
+                            error: message
                         });
                     }));
                 });
@@ -173,9 +175,11 @@
                     }
 
                 }, function(response){
+                	var message = "Submit failed but no error response was received";
+                	if (response && response.message) message = response.message;
                     that.failedSubmissions.push({
                         inputEntityIds: _.map(inputEntities, 'entityId').join(', '),
-                        error: response || "No error response"
+                        error: message
                     });
                 }));
             }

--- a/src/main/webapp/scripts/services/ijp.service.js
+++ b/src/main/webapp/scripts/services/ijp.service.js
@@ -127,7 +127,7 @@
               sessionId: facility.icat().session().sessionId
             }).then(function(response){
               out.resolve(response);
-            }, function(){ out.reject(); });
+            }, function(response){ out.reject(response); });
             return out.promise
           },
           'string, array': function(jobType, jobParameters){
@@ -139,7 +139,7 @@
             }, true);
             this.post('submit', params, {}).then(function(response){
               out.resolve(response);
-            }, function(){ out.reject(); });
+            }, function(response){ out.reject(response); });
             return out.promise
           }
         });


### PR DESCRIPTION
ijp.service/submitJob now passes any error response from the post
request back (as a rejection); configure-job.controller/submitJob now
reports any message in the rejection response back to the user.
Fixes #45 .